### PR TITLE
Fixed memory leak related to matplotlib.

### DIFF
--- a/src/02_train_savi.py
+++ b/src/02_train_savi.py
@@ -42,7 +42,7 @@ class Trainer(BaseTrainer):
         loss: torch.Tensor
             Total loss for the current batch
         """
-        videos, targets, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
+        videos, targets, _, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
 
         # forward pass
         videos, targets = videos.to(self.device), targets.to(self.device)
@@ -79,7 +79,7 @@ class Trainer(BaseTrainer):
         if(iter_ % self.exp_params["training_slots"]["image_log_frequency"] != 0):
             return
 
-        videos, targets, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
+        videos, targets, _, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
         out_model, _ = self.forward_loss_metric(
                 batch_data=batch_data,
                 training=False,

--- a/src/02_train_savi.py
+++ b/src/02_train_savi.py
@@ -2,6 +2,9 @@
 Training and Validating a SAVi video decomposition model
 """
 
+import matplotlib
+import matplotlib.pyplot as plt
+matplotlib.use('Agg')  # for avoiding memory leak
 import torch
 
 from data.load_data import unwrap_batch_data
@@ -105,7 +108,7 @@ class Trainer(BaseTrainer):
             )
 
         # Rendered individual objects
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 individual_recons_history[0][:N].clamp(0, 1),
                 savepath=None,
                 tag="objects_decomposed",
@@ -114,9 +117,10 @@ class Trainer(BaseTrainer):
                 tb_writer=self.writer,
                 iter=iter_
             )
+        plt.close(fig)
 
         # Rendered individual object masks
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 masks_history[0][:N].clamp(0, 1),
                 savepath=None,
                 tag="masks",
@@ -126,10 +130,11 @@ class Trainer(BaseTrainer):
                 tb_writer=self.writer,
                 iter=iter_,
             )
+        plt.close(fig)
 
         # Rendered individual combination of an object with its masks
         recon_combined = masks_history[0][:N] * individual_recons_history[0][:N]
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 recon_combined.clamp(0, 1),
                 savepath=None,
                 tag="reconstruction_combined",
@@ -138,6 +143,7 @@ class Trainer(BaseTrainer):
                 tb_writer=self.writer,
                 iter=iter_
             )
+        plt.close(fig)
         return
 
 

--- a/src/03_evaluate_savi.py
+++ b/src/03_evaluate_savi.py
@@ -54,7 +54,7 @@ class Evaluator(BaseEvaluator):
         pred_data: dict
             Predictions from the model for the current batch of data
         """
-        videos, masks, initializer_kwargs = unwrap_batch_data_masks(self.exp_params, batch_data)
+        videos, masks, _, initializer_kwargs = unwrap_batch_data_masks(self.exp_params, batch_data)
         videos, masks = videos.to(self.device), masks.to(self.device)
         out_model = self.model(
                 videos,

--- a/src/03_evaluate_savi_noMasks.py
+++ b/src/03_evaluate_savi_noMasks.py
@@ -46,7 +46,7 @@ class Evaluator(BaseEvaluator):
         pred_data: dict
             Predictions from the model for the current batch of data
         """
-        videos, targets, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
+        videos, targets, _, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
         videos, targets = videos.to(self.device), targets.to(self.device)
         out_model = self.model(
                 videos,

--- a/src/04_train_predictor.py
+++ b/src/04_train_predictor.py
@@ -2,7 +2,9 @@
 Training and Validation of an object-centric predictor module using a frozen and pretrained
 SAVI video decomposition model
 """
-
+import matplotlib
+import matplotlib.pyplot as plt
+matplotlib.use('Agg')  # for avoiding memory leak
 import torch
 
 from data.load_data import unwrap_batch_data
@@ -121,15 +123,17 @@ class Trainer(BasePredictorTrainer):
                 savepath=None
             )
             self.writer.add_figure(tag=f"Qualitative Eval {k+1}", figure=fig, step=epoch + 1)
+            plt.close(fig)
 
             objs = pred_masks[k*num_preds:(k+1)*num_preds] * pred_recons[k*num_preds:(k+1)*num_preds]
-            _ = visualize_decomp(
+            fig, _, _ = visualize_decomp(
                     objs.clamp(0, 1),
                     savepath=None,
                     tag=f"Pred. Object Recons. {k+1}",
                     tb_writer=self.writer,
                     iter=epoch
                 )
+            plt.close(fig)
         return
 
 

--- a/src/06_generate_figs_pred.py
+++ b/src/06_generate_figs_pred.py
@@ -3,6 +3,8 @@ Generating some figures using a pretrained SAVi model and the corresponding pred
 """
 
 import os
+
+import matplotlib.pyplot as plt
 from tqdm import tqdm
 import numpy as np
 import torch
@@ -193,10 +195,11 @@ class FigGenerator(BaseFigGenerator):
         pred_objs = add_border(pred_objs * pred_masks, color_name="red", pad=2)
         pred_objs = pred_objs.reshape(B, num_preds, num_slots, *pred_objs.shape[-3:])
         all_objs = torch.cat([seed_objs, pred_objs], dim=1)
-        _ = visualize_aligned_slots(
+        fig, _ = visualize_aligned_slots(
                 all_objs[0],
                 savepath=os.path.join(self.plots_path, cur_dir, "aligned_slots.png")
             )
+        plt.close(fig)
 
         # Video predictions
         fig, ax = visualize_qualitative_eval(
@@ -205,12 +208,14 @@ class FigGenerator(BaseFigGenerator):
                 preds=pred_imgs[0],
                 savepath=os.path.join(self.plots_path, cur_dir, "qual_eval_rgb.png")
             )
+        plt.close(fig)
         fig, ax = visualize_qualitative_eval(
                 context=seed_imgs[0],
                 targets=target_imgs[0],
                 preds=pred_imgs[0],
                 savepath=os.path.join(self.plots_path, cur_dir, "qual_eval.png")
             )
+        plt.close(fig)
         fig, ax = visualize_tight_row(
                 frames=videos[0],
                 num_context=num_context,
@@ -218,6 +223,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=True,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_rgb_gt.png")
             )
+        plt.close(fig)
         fig, ax = visualize_tight_row(
                 frames=pred_imgs[0],
                 num_context=num_context,
@@ -225,6 +231,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=False,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_rgb_pred.png")
             )
+        plt.close(fig)
 
         # masks
         seed_masks_categorical = seed_masks[0, :num_context].argmax(dim=1)
@@ -242,6 +249,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=True,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_masks.png")
             )
+        plt.close(fig)
 
         # overlay masks
         masks_categorical_channels = idx_to_one_hot(x=all_masks_categorical[:, 0])
@@ -258,6 +266,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=True,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_overlay.png")
             )
+        plt.close(fig)
 
         # Sequence GIFs
         gt_frames = torch.cat([seed_imgs, target_imgs], dim=1)

--- a/src/06_generate_figs_savi.py
+++ b/src/06_generate_figs_savi.py
@@ -46,7 +46,7 @@ class FigGenerator(BaseFigGenerator):
         """
         Computing visualization
         """
-        videos, targets, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
+        videos, targets, _, initializer_kwargs = unwrap_batch_data(self.exp_params, batch_data)
         videos, targets = videos.to(self.device), targets.to(self.device)
         out_model = self.model(videos, num_imgs=videos.shape[1], **initializer_kwargs)
         slot_history, reconstruction_history, individual_recons_history, masks_history = out_model

--- a/src/06_generate_figs_savi.py
+++ b/src/06_generate_figs_savi.py
@@ -3,6 +3,8 @@ Generating figures using a pretrained SAVI model
 """
 
 import os
+
+import matplotlib.pyplot as plt
 import torch
 
 from base.baseFigGenerator import BaseFigGenerator
@@ -70,30 +72,33 @@ class FigGenerator(BaseFigGenerator):
             )
 
         savepath = os.path.join(self.plots_path, cur_dir, f"Objects_{img_idx+1}.png")
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 individual_recons_history[0, :N],
                 savepath=savepath,
                 vmin=0,
                 vmax=1,
             )
+        plt.close(fig)
 
         savepath = os.path.join(self.plots_path, cur_dir, f"masks_{img_idx+1}.png")
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 masks_history[0][:N],
                 savepath=savepath,
                 cmap="gray_r",
                 vmin=0,
                 vmax=1,
             )
+        plt.close(fig)
         savepath = os.path.join(self.plots_path, cur_dir, f"maskedObj_{img_idx+1}.png")
         recon_combined = masks_history[0][:N] * individual_recons_history[0][:N]
         recon_combined = torch.clamp(recon_combined, min=0, max=1)
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 recon_combined,
                 savepath=savepath,
                 vmin=0,
                 vmax=1,
             )
+        plt.close(fig)
         return
 
 

--- a/src/CONFIG.py
+++ b/src/CONFIG.py
@@ -29,8 +29,8 @@ METRICS = [
         "mse", "psnr", "ssim", "lpips"      # video predicition metrics
     ]
 MODELS = ["SAVi"]
-PREDICTORS = ["LSTM", "Transformer", "OCVP-Seq", "OCVP-Par"]
-INITIALIZERS = ["Random", "LearnedRandom", "Masks", "CoM", "BBox"]
+PREDICTORS = ["LSTM", "Transformer", "OCVP-Seq", "OCVP-Par", "CondTransformer"]
+INITIALIZERS = ["Random", "LearnedRandom", "Learned", "Masks", "CoM", "BBox"]
 
 DEFAULTS = {
     "dataset": {
@@ -88,6 +88,15 @@ DEFAULTS = {
                 "input_buffer_size": None
             },
             "OCVP-Par": {
+                "token_dim": 128,
+                "hidden_dim": 256,
+                "num_layers": 2,
+                "n_heads": 4,
+                "residual": True,
+                "input_buffer_size": None
+            },
+            "CondTransformer": {
+                "cond_dim": 4,
                 "token_dim": 128,
                 "hidden_dim": 256,
                 "num_layers": 2,

--- a/src/CONFIG.py
+++ b/src/CONFIG.py
@@ -18,7 +18,7 @@ CONFIG = {
 
 
 # Supported datasets, models, metrics, and so on
-DATASETS = ["OBJ3D", "MoviA", "MoviC"]
+DATASETS = ["OBJ3D", "MoviA", "MoviC", "ReachSpecificTarget_0Distractors_LargeTargets_DenseReward_DictstateObs_FrontviewViewpointSimplifiedRobot-dataset"]
 LOSSES = [
         "mse", "l2",      # standard losses
         "pred_img_mse",   # ||pred_img - target_img||^2 when predicting future images

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -4,5 +4,6 @@ Accessing datasets from script
 
 from .Movi import MOVI
 from .obj3d import OBJ3D
+from .robot_dataset import RobotDataset
 
 from .load_data import load_data, build_data_loader, unwrap_batch_data, unwrap_batch_data_masks

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -4,7 +4,7 @@ Methods for loading specific datasets, fitting data loaders and other
 
 # from torchvision import datasets
 from torch.utils.data import DataLoader
-from data import OBJ3D, MOVI
+from data import OBJ3D, MOVI, RobotDataset
 from CONFIG import CONFIG, DATASETS
 
 
@@ -51,6 +51,12 @@ def load_data(exp_params, split="train"):
                 random_start=exp_params["dataset"].get("random_start", False),
                 slot_initializer=exp_params["model"]["SAVi"].get("initializer", "LearnedRandom")
             )
+    elif "Robot-dataset" in dataset_name:
+        dataset = RobotDataset(
+                mode=split,
+                dataset_name=dataset_name,
+                sample_length=exp_params["training_prediction"]["sample_length"]
+            )
     else:
         raise NotImplementedError(
                 f"""ERROR! Dataset'{dataset_name}' is not available.
@@ -96,6 +102,8 @@ def unwrap_batch_data(exp_params, batch_data):
         initializer_kwargs["instance_masks"] = all_reps["masks"]
         initializer_kwargs["com_coords"] = all_reps["com_coords"]
         initializer_kwargs["bbox_coords"] = all_reps["bbox_coords"]
+    elif "Robot-dataset" in exp_params["dataset"]["dataset_name"]:
+      videos, targets, condition, _ = batch_data
     else:
         dataset_name = exp_params["dataset"]["dataset_name"]
         raise NotImplementedError(f"Dataset {dataset_name} is not supported...")

--- a/src/data/load_data.py
+++ b/src/data/load_data.py
@@ -95,6 +95,7 @@ def unwrap_batch_data(exp_params, batch_data):
     Unwrapping the batch data depending on the dataset that we are training on
     """
     initializer_kwargs = {}
+    condition = None
     if exp_params["dataset"]["dataset_name"] in ["OBJ3D"]:
         videos, targets, _ = batch_data
     elif exp_params["dataset"]["dataset_name"] in ["MoviA", "MoviC"]:
@@ -107,7 +108,7 @@ def unwrap_batch_data(exp_params, batch_data):
     else:
         dataset_name = exp_params["dataset"]["dataset_name"]
         raise NotImplementedError(f"Dataset {dataset_name} is not supported...")
-    return videos, targets, initializer_kwargs
+    return videos, targets, condition, initializer_kwargs
 
 
 def unwrap_batch_data_masks(exp_params, batch_data):
@@ -118,6 +119,7 @@ def unwrap_batch_data_masks(exp_params, batch_data):
     dbs = ["MoviA", "MoviC"]
     dataset_name = exp_params["dataset"]["dataset_name"]
     initializer_kwargs = {}
+    condition = None
     if dataset_name in ["MoviA", "MoviC"]:
         videos, _, all_reps = batch_data
         masks = all_reps["masks"]
@@ -126,7 +128,7 @@ def unwrap_batch_data_masks(exp_params, batch_data):
         initializer_kwargs["bbox_coords"] = all_reps["bbox_coords"]
     else:
         raise ValueError(f"Only {dbs} support object-based mask evaluation. Given {dataset_name = }")
-    return videos, masks, initializer_kwargs
+    return videos, masks, condition, initializer_kwargs
 
 
 #

--- a/src/data/robot_dataset.py
+++ b/src/data/robot_dataset.py
@@ -1,0 +1,102 @@
+import numpy as np
+from torchvision import transforms
+import glob
+import os
+import os.path as osp
+import torch
+from PIL import Image
+
+from data import OBJ3D
+from CONFIG import CONFIG
+
+PATH = CONFIG["paths"]["data_path"]
+
+
+class RobotDataset(OBJ3D):
+    """
+    DataClass for datasets generated with the visual-block-builder package.
+
+    During training, we sample a random subset of frames in the episode. At inference time,
+    we always start from the first frame, e.g., when the ball moves towards the objects, and
+    before any collision happens.
+
+    Args:
+    -----
+    mode: string
+        Dataset split to load. Can be one of ['train', 'val', 'test']
+    ep_len: int
+        Number of frames in an episode. Default is 30
+    sample_length: int
+        Number of frames in the sequences to load
+    random_start: bool
+        If True, first frame of the sequence is sampled at random between the possible starting frames.
+        Otherwise, starting frame is always the first frame in the sequence.
+    """
+
+    def __init__(self, mode, dataset_name, ep_len=30, sample_length=20, random_start=True):
+        """
+        Dataset Initializer
+        """
+        super().__init__(mode, ep_len, sample_length, random_start)
+
+        assert mode in ["train", "val", "valid", "eval", "test"], f"Unknown dataset split {mode}..."
+        mode = "val" if mode in ["val", "valid"] else mode
+        mode = "test" if mode in ["test", "eval"] else mode
+        assert mode in ['train', 'val', 'test'], f"Unknown dataset split {mode}..."
+
+        self.root = os.path.join(PATH, dataset_name, mode)
+        self.mode = mode
+        self.sample_length = sample_length
+        self.random_start = random_start
+
+        # Get all numbers
+        self.folders = []
+        for file in os.listdir(self.root):
+            try:
+                self.folders.append(int(file))
+            except ValueError:
+                continue
+        self.folders.sort()
+
+        # episode-related paramters
+        self.epsisodes = []
+        self.EP_LEN = ep_len
+        if mode == "train" and self.random_start:
+            self.seq_per_episode = self.EP_LEN - self.sample_length + 1
+        else:
+            self.seq_per_episode = 1
+
+        # loading images from data directories and assembling then into episodes
+        for f in self.folders:
+            dir_name = os.path.join(self.root, str(f))
+            paths = list(glob.glob(osp.join(dir_name, '*.png')))
+            get_num = lambda x: int(osp.splitext(osp.basename(x))[0])
+            paths.sort(key=get_num)
+            self.epsisodes.append(paths)
+        return
+
+    def __getitem__(self, index):
+        """
+        Fetching a sequence from the dataset
+        """
+        imgs = []
+
+        # Implement continuous indexing
+        ep = index // self.seq_per_episode
+        offset = index % self.seq_per_episode
+        end = offset + self.sample_length
+
+        e = self.epsisodes[ep]
+        for image_index in range(offset, end):
+            img = Image.open(osp.join(e[image_index]))
+            img = img.resize((64, 64))
+            img = transforms.ToTensor()(img)[:3]
+            imgs.append(img)
+        img = torch.stack(imgs, dim=0).float()
+
+        # load actions
+        actions = torch.from_numpy(np.load("/" + osp.join(*(self.epsisodes[ep][0].split("/")[:-1] + ["actions.npy"])))[offset:end])
+
+        targets = img
+        all_reps = {"videos": img}
+        return img, targets, actions, all_reps

--- a/src/lib/setup_model.py
+++ b/src/lib/setup_model.py
@@ -120,6 +120,20 @@ def setup_predictor(exp_params):
                 residual=cur_predictor_params.get("residual", False),
                 input_buffer_size=cur_predictor_params.get("input_buffer_size", num_seed)
             )
+    elif(predictor_name == "CondTransformer"):
+        num_seed = train_pred_params["num_context"]
+        predictor = predictors.CondTransformerPredictor(
+                num_slots=cur_model_params["num_slots"],
+                slot_dim=cur_model_params["slot_dim"],
+                num_imgs=train_pred_params["sample_length"],
+                token_dim=cur_predictor_params["token_dim"],
+                hidden_dim=cur_predictor_params["hidden_dim"],
+                cond_dim=cur_predictor_params["cond_dim"],
+                num_layers=cur_predictor_params["num_layers"],
+                n_heads=cur_predictor_params["n_heads"],
+                residual=cur_predictor_params.get("residual", False),
+                input_buffer_size=cur_predictor_params.get("input_buffer_size", num_seed)
+            )
     else:
         raise NotImplementedError(f"Predictor '{predictor_name}' not in recognized predictors: {PREDICTORS}")
 

--- a/src/lib/visualizations.py
+++ b/src/lib/visualizations.py
@@ -165,6 +165,8 @@ def visualize_recons(imgs, recons, savepath=None,  tag="recons", n_cols=10, tb_w
     if tb_writer is not None:
         tb_writer.add_images(fig_name=f"{tag}_imgs", img_grid=np.array(imgs), step=iter)
         tb_writer.add_images(fig_name=f"{tag}_recons", img_grid=np.array(recons), step=iter)
+
+    plt.close(fig)
     return
 
 
@@ -185,6 +187,7 @@ def visualize_img_err(img, reconstructions):
 
     plt.tight_layout()
     plt.show()
+    plt.close()
     return
 
 
@@ -303,6 +306,8 @@ def visualize_frame_predictions(context_imgs, pred_imgs, target_imgs, tb_writer=
                     img_grid=np.array(pred_imgs.cpu().detach()),
                     step=step
                 )
+
+    plt.close(fig)
     return
 
 
@@ -521,6 +526,8 @@ def visualize_metric(vals, start_x=0, title=None, xlabel=None, savepath=None, **
     plt.tight_layout()
     if savepath is not None:
         plt.savefig(savepath)
+
+    plt.close(fig)
     return
 
 

--- a/src/models/model_blocks.py
+++ b/src/models/model_blocks.py
@@ -247,5 +247,22 @@ class PositionalEncoding(nn.Module):
         y = self.dropout(x)
         return y
 
+    def forward_cond(self, x, batch_size):
+        """
+        Adding the positional encoding to the input condition input token of the transformer
+
+        Args:
+        -----
+        x: torch Tensor
+            Token to enhance with positional encoding. Shape is (B, Token_Dim)
+        batch_size: int
+            Given batch size to repeat the positional encoding for
+        """
+        if x.device != self.pe.device:
+            self.pe = self.pe.to(x.device)
+        cur_pe = self.pe.repeat(batch_size, 1, 1, 1)[:, -1].squeeze()
+        x = x + cur_pe
+        y = self.dropout(x)
+        return y
 
 #


### PR DESCRIPTION
There were two problems in connection with the visualizations with `matplotlib`, which led to a memory leak and, in the case of long training times, to the killing of the training script.

1. Firstly, created figures were not closed properly after use. Solution: `plt.close(fig)`
2. Unfortunately, this did not completely solve the memory leak, so I explicitly set the backend of `matplotlib` (`matplotlib.use('Agg')` based on [this](https://stackoverflow.com/questions/2364945/matplotlib-runs-out-of-memory-when-plotting-in-a-loop)). This fixed the memory leak completely.