### PR TITLE
Fixed memory leak related to matplotlib.

### DIFF
--- a/src/02_train_savi.py
+++ b/src/02_train_savi.py
@@ -2,6 +2,9 @@
 Training and Validating a SAVi video decomposition model
 """
 
+import matplotlib
+import matplotlib.pyplot as plt
+matplotlib.use('Agg')  # for avoiding memory leak
 import torch
 
 from data.load_data import unwrap_batch_data
@@ -105,7 +108,7 @@ class Trainer(BaseTrainer):
             )
 
         # Rendered individual objects
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 individual_recons_history[0][:N].clamp(0, 1),
                 savepath=None,
                 tag="objects_decomposed",
@@ -114,9 +117,10 @@ class Trainer(BaseTrainer):
                 tb_writer=self.writer,
                 iter=iter_
             )
+        plt.close(fig)
 
         # Rendered individual object masks
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 masks_history[0][:N].clamp(0, 1),
                 savepath=None,
                 tag="masks",
@@ -126,10 +130,11 @@ class Trainer(BaseTrainer):
                 tb_writer=self.writer,
                 iter=iter_,
             )
+        plt.close(fig)
 
         # Rendered individual combination of an object with its masks
         recon_combined = masks_history[0][:N] * individual_recons_history[0][:N]
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 recon_combined.clamp(0, 1),
                 savepath=None,
                 tag="reconstruction_combined",
@@ -138,6 +143,7 @@ class Trainer(BaseTrainer):
                 tb_writer=self.writer,
                 iter=iter_
             )
+        plt.close(fig)
         return
 
 

--- a/src/04_train_predictor.py
+++ b/src/04_train_predictor.py
@@ -2,7 +2,9 @@
 Training and Validation of an object-centric predictor module using a frozen and pretrained
 SAVI video decomposition model
 """
-
+import matplotlib
+import matplotlib.pyplot as plt
+matplotlib.use('Agg')  # for avoiding memory leak
 import torch
 
 from data.load_data import unwrap_batch_data
@@ -121,15 +123,17 @@ class Trainer(BasePredictorTrainer):
                 savepath=None
             )
             self.writer.add_figure(tag=f"Qualitative Eval {k+1}", figure=fig, step=epoch + 1)
+            plt.close(fig)
 
             objs = pred_masks[k*num_preds:(k+1)*num_preds] * pred_recons[k*num_preds:(k+1)*num_preds]
-            _ = visualize_decomp(
+            fig, _, _ = visualize_decomp(
                     objs.clamp(0, 1),
                     savepath=None,
                     tag=f"Pred. Object Recons. {k+1}",
                     tb_writer=self.writer,
                     iter=epoch
                 )
+            plt.close(fig)
         return
 
 

--- a/src/06_generate_figs_pred.py
+++ b/src/06_generate_figs_pred.py
@@ -3,6 +3,8 @@ Generating some figures using a pretrained SAVi model and the corresponding pred
 """
 
 import os
+
+import matplotlib.pyplot as plt
 from tqdm import tqdm
 import numpy as np
 import torch
@@ -193,10 +195,11 @@ class FigGenerator(BaseFigGenerator):
         pred_objs = add_border(pred_objs * pred_masks, color_name="red", pad=2)
         pred_objs = pred_objs.reshape(B, num_preds, num_slots, *pred_objs.shape[-3:])
         all_objs = torch.cat([seed_objs, pred_objs], dim=1)
-        _ = visualize_aligned_slots(
+        fig, _ = visualize_aligned_slots(
                 all_objs[0],
                 savepath=os.path.join(self.plots_path, cur_dir, "aligned_slots.png")
             )
+        plt.close(fig)
 
         # Video predictions
         fig, ax = visualize_qualitative_eval(
@@ -205,12 +208,14 @@ class FigGenerator(BaseFigGenerator):
                 preds=pred_imgs[0],
                 savepath=os.path.join(self.plots_path, cur_dir, "qual_eval_rgb.png")
             )
+        plt.close(fig)
         fig, ax = visualize_qualitative_eval(
                 context=seed_imgs[0],
                 targets=target_imgs[0],
                 preds=pred_imgs[0],
                 savepath=os.path.join(self.plots_path, cur_dir, "qual_eval.png")
             )
+        plt.close(fig)
         fig, ax = visualize_tight_row(
                 frames=videos[0],
                 num_context=num_context,
@@ -218,6 +223,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=True,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_rgb_gt.png")
             )
+        plt.close(fig)
         fig, ax = visualize_tight_row(
                 frames=pred_imgs[0],
                 num_context=num_context,
@@ -225,6 +231,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=False,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_rgb_pred.png")
             )
+        plt.close(fig)
 
         # masks
         seed_masks_categorical = seed_masks[0, :num_context].argmax(dim=1)
@@ -242,6 +249,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=True,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_masks.png")
             )
+        plt.close(fig)
 
         # overlay masks
         masks_categorical_channels = idx_to_one_hot(x=all_masks_categorical[:, 0])
@@ -258,6 +266,7 @@ class FigGenerator(BaseFigGenerator):
                 is_gt=True,
                 savepath=os.path.join(self.plots_path, cur_dir, "row_overlay.png")
             )
+        plt.close(fig)
 
         # Sequence GIFs
         gt_frames = torch.cat([seed_imgs, target_imgs], dim=1)

--- a/src/06_generate_figs_savi.py
+++ b/src/06_generate_figs_savi.py
@@ -3,6 +3,8 @@ Generating figures using a pretrained SAVI model
 """
 
 import os
+
+import matplotlib.pyplot as plt
 import torch
 
 from base.baseFigGenerator import BaseFigGenerator
@@ -70,30 +72,33 @@ class FigGenerator(BaseFigGenerator):
             )
 
         savepath = os.path.join(self.plots_path, cur_dir, f"Objects_{img_idx+1}.png")
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 individual_recons_history[0, :N],
                 savepath=savepath,
                 vmin=0,
                 vmax=1,
             )
+        plt.close(fig)
 
         savepath = os.path.join(self.plots_path, cur_dir, f"masks_{img_idx+1}.png")
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 masks_history[0][:N],
                 savepath=savepath,
                 cmap="gray_r",
                 vmin=0,
                 vmax=1,
             )
+        plt.close(fig)
         savepath = os.path.join(self.plots_path, cur_dir, f"maskedObj_{img_idx+1}.png")
         recon_combined = masks_history[0][:N] * individual_recons_history[0][:N]
         recon_combined = torch.clamp(recon_combined, min=0, max=1)
-        _ = visualize_decomp(
+        fig, _, _ = visualize_decomp(
                 recon_combined,
                 savepath=savepath,
                 vmin=0,
                 vmax=1,
             )
+        plt.close(fig)
         return
 
 

--- a/src/lib/visualizations.py
+++ b/src/lib/visualizations.py
@@ -165,6 +165,8 @@ def visualize_recons(imgs, recons, savepath=None,  tag="recons", n_cols=10, tb_w
     if tb_writer is not None:
         tb_writer.add_images(fig_name=f"{tag}_imgs", img_grid=np.array(imgs), step=iter)
         tb_writer.add_images(fig_name=f"{tag}_recons", img_grid=np.array(recons), step=iter)
+
+    plt.close(fig)
     return
 
 
@@ -185,6 +187,7 @@ def visualize_img_err(img, reconstructions):
 
     plt.tight_layout()
     plt.show()
+    plt.close()
     return
 
 
@@ -303,6 +306,8 @@ def visualize_frame_predictions(context_imgs, pred_imgs, target_imgs, tb_writer=
                     img_grid=np.array(pred_imgs.cpu().detach()),
                     step=step
                 )
+
+    plt.close(fig)
     return
 
 
@@ -521,6 +526,8 @@ def visualize_metric(vals, start_x=0, title=None, xlabel=None, savepath=None, **
     plt.tight_layout()
     if savepath is not None:
         plt.savefig(savepath)
+
+    plt.close(fig)
     return
 
 


### PR DESCRIPTION
There were two problems in connection with the visualizations with `matplotlib`, which led to a memory leak and, in the case of long training times, to the killing of the training script.

1. Firstly, created figures were not closed properly after use. Solution: `plt.close(fig)`
2. Unfortunately, this did not completely solve the memory leak, so I explicitly set the backend of `matplotlib` (`matplotlib.use('Agg')` based on [this](https://stackoverflow.com/questions/2364945/matplotlib-runs-out-of-memory-when-plotting-in-a-loop)). This fixed the memory leak completely.